### PR TITLE
test: validate referenced PWA assets

### DIFF
--- a/tests/static-smoke.mjs
+++ b/tests/static-smoke.mjs
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { Script } from "node:vm";
 
 const rootFiles = {
@@ -22,6 +22,7 @@ assert(html.includes("Exchange connection codes"), "Expected code exchange UI");
 assert(html.includes("Simple mode"), "Expected simplified UI mode");
 assert(html.includes("That code does not look valid"), "Expected invalid-code error copy");
 assert(html.includes("aria-live=\"polite\""), "Expected accessible live status region");
+assert(html.includes('rel="manifest" href="manifest.json"'), "Expected manifest link");
 
 const requiredIds = [
   "appStatus",
@@ -49,6 +50,12 @@ new Script(inlineScript[1], { filename: "index-inline.js" });
 assert(manifest.name === "PeerCall - private browser audio calls", "Expected English manifest name");
 assert(manifest.display === "standalone", "Expected standalone PWA display mode");
 assert(Array.isArray(manifest.icons) && manifest.icons.length >= 2, "Expected PWA icons");
+
+for (const icon of manifest.icons) {
+  assert(typeof icon.src === "string" && icon.src.length > 0, "Expected every manifest icon to have a source");
+  await access(icon.src);
+  assert(serviceWorker.includes(`./${icon.src}`), `Expected service worker to cache manifest icon: ${icon.src}`);
+}
 
 new Script(serviceWorker, { filename: "sw.js" });
 assert(serviceWorker.includes("peercall-v3"), "Expected current cache version");


### PR DESCRIPTION
## Summary
- verify the HTML links the web app manifest
- verify every manifest icon path exists
- verify every manifest icon is included in the service worker precache list

## Why
A missing or renamed icon can silently break PWA installation or offline startup while the current smoke test still passes. These checks turn those asset relationships into a regression-tested contract.

## Verification
- reviewed the updated test from the branch
- GitHub Actions runs `npm test` for pull requests