### PR TITLE
Validate service worker precache assets

### DIFF
--- a/tests/static-smoke.mjs
+++ b/tests/static-smoke.mjs
@@ -48,7 +48,12 @@ assert(inlineScript, "Expected one inline script");
 new Script(inlineScript[1], { filename: "index-inline.js" });
 
 assert(manifest.name === "PeerCall - private browser audio calls", "Expected English manifest name");
+assert(manifest.short_name === "PeerCall", "Expected compact manifest short name");
+assert(manifest.start_url === ".", "Expected relative PWA start URL");
+assert(manifest.scope === ".", "Expected relative PWA scope");
 assert(manifest.display === "standalone", "Expected standalone PWA display mode");
+assert(/^#[0-9a-f]{6}$/iu.test(manifest.background_color), "Expected valid manifest background color");
+assert(/^#[0-9a-f]{6}$/iu.test(manifest.theme_color), "Expected valid manifest theme color");
 assert(Array.isArray(manifest.icons) && manifest.icons.length >= 2, "Expected PWA icons");
 
 for (const icon of manifest.icons) {
@@ -61,5 +66,17 @@ new Script(serviceWorker, { filename: "sw.js" });
 assert(serviceWorker.includes("peercall-v3"), "Expected current cache version");
 assert(serviceWorker.includes("skipWaiting"), "Expected service worker update flow");
 assert(serviceWorker.includes("clients.claim"), "Expected service worker activation claim");
+
+const assetListMatch = serviceWorker.match(/const APP_ASSETS = \[([\s\S]*?)\];/u);
+assert(assetListMatch, "Expected a static service worker asset list");
+const precacheAssets = [...assetListMatch[1].matchAll(/["'](.+?)["']/gu)].map((match) => match[1]);
+assert(precacheAssets.length > 0, "Expected at least one precached asset");
+assert(new Set(precacheAssets).size === precacheAssets.length, "Expected unique precache asset paths");
+
+for (const asset of precacheAssets) {
+  assert(asset.startsWith("./"), `Expected relative precache asset path: ${asset}`);
+  const localPath = asset === "./" ? "." : asset.slice(2);
+  await access(localPath);
+}
 
 console.log("PeerCall static smoke checks passed.");


### PR DESCRIPTION
## Summary
- validate required PWA manifest fields and color values
- parse the service worker precache list during smoke tests
- verify every precached path is unique, relative, and exists on disk

## Why
A stale or mistyped service worker asset path can break installation or offline startup while the normal page still appears healthy. These checks catch that class of regression without adding dependencies.

## Verification
- existing inline JavaScript and service worker syntax checks remain in place
- the test validates the current manifest and every current `APP_ASSETS` entry