### PR TITLE
ci: cancel stale runs and cap smoke test time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: static-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed
- cancel an older workflow run when a newer commit arrives for the same branch or pull request
- stop the smoke-test job after 10 minutes if a command hangs

## Why
This keeps CI feedback relevant, avoids wasting Actions minutes on superseded commits, and prevents a stalled dependency setup or test process from running indefinitely.

## Verification
The existing `npm test` command and Node.js version are unchanged. GitHub Actions will validate the updated workflow on this pull request.