### PR TITLE
Fix service worker offline fallback for non-navigation requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -49,7 +49,12 @@ self.addEventListener("fetch", (event) => {
           }
           return response;
         })
-        .catch(() => caches.match("./index.html"));
+        .catch((error) => {
+          if (event.request.mode === "navigate") {
+            return caches.match("./index.html");
+          }
+          throw error;
+        });
     })
   );
 });

--- a/tests/static-smoke.mjs
+++ b/tests/static-smoke.mjs
@@ -134,6 +134,14 @@ new Script(serviceWorker, { filename: "sw.js" });
 assert(serviceWorker.includes("peercall-v3"), "Expected current cache version");
 assert(serviceWorker.includes("skipWaiting"), "Expected service worker update flow");
 assert(serviceWorker.includes("clients.claim"), "Expected service worker activation claim");
+assert(
+  serviceWorker.includes('event.request.mode === "navigate"'),
+  "Expected offline document fallback to be limited to navigation requests"
+);
+assert(
+  !/\.catch\(\(\)\s*=>\s*caches\.match\(["']\.\/index\.html["']\)\)/u.test(serviceWorker),
+  "Expected non-navigation fetch failures not to be replaced with index.html"
+);
 
 const assetListMatch = serviceWorker.match(/const APP_ASSETS = \[([\s\S]*?)\];/u);
 assert(assetListMatch, "Expected a static service worker asset list");


### PR DESCRIPTION
## What changed
- return the cached app shell only for failed navigation requests
- let failed non-navigation requests preserve their actual network failure
- add static smoke coverage so `index.html` cannot accidentally become a fallback for every GET request again

## Why
The previous catch handler returned `index.html` for any same-origin GET failure. Offline icon, manifest, or other asset requests could therefore receive HTML instead of failing normally, hiding the real error and producing invalid resource responses.

## Validation
- existing static smoke suite remains the CI gate
- new assertions verify the fallback is navigation-only