### PR TITLE
docs: add browser compatibility verification matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm test
 - Audio only; no video or group calls.
 - Manual code exchange is intentionally simple but not as convenient as server-assisted signaling.
 - There is no bundled TURN server, so some restrictive networks may fail to connect.
-- Browser behavior differs across mobile platforms, especially around backgrounding, audio autoplay, and installed PWA behavior.
+- Browser behavior differs across mobile platforms, especially around backgrounding, audio autoplay, and installed PWA behavior. See the [browser compatibility matrix](docs/browser-compatibility.md) for the repeatable verification procedure and recorded results.
 
 ## Roadmap
 

--- a/docs/browser-compatibility.md
+++ b/docs/browser-compatibility.md
@@ -1,0 +1,37 @@
+# Browser Compatibility Matrix
+
+PeerCall relies on browser WebRTC, microphone permission, clipboard-friendly manual offer/answer exchange, and PWA behavior. Use this matrix to record repeatable compatibility checks before releases.
+
+Do not mark a browser as supported from API availability alone. Run the end-to-end caller/callee flow on real devices or representative environments and record the tested version and date.
+
+## Test matrix
+
+| Browser / mode | Microphone | Offer/answer exchange | Audio on normal network | Backgrounding | Installed PWA | Last verified |
+| --- | --- | --- | --- | --- | --- | --- |
+| Desktop Chrome | Not verified | Not verified | Not verified | Not verified | N/A | — |
+| Desktop Firefox | Not verified | Not verified | Not verified | Not verified | N/A | — |
+| Desktop Safari | Not verified | Not verified | Not verified | Not verified | N/A | — |
+| Android Chrome | Not verified | Not verified | Not verified | Not verified | Not verified | — |
+| iOS Safari | Not verified | Not verified | Not verified | Not verified | Not verified | — |
+
+`Not verified` is intentional: it distinguishes an untested environment from a known failure and avoids presenting assumptions as compatibility claims.
+
+## How to verify a row
+
+1. Record the browser version, OS version, device model (for mobile), and test date.
+2. Open PeerCall over HTTPS or localhost and allow microphone access.
+3. Complete a full caller/callee offer and answer exchange between two tabs or devices.
+4. Confirm both peers receive remote audio on a normal home or mobile network.
+5. On mobile, background and restore the app and record whether the call survives, pauses, or requires reconnection.
+6. Where installation is available, repeat the flow in installed PWA mode and record any differences from the browser tab.
+7. Note autoplay prompts, permission quirks, strict-NAT failures, or other reproducible limitations below the table.
+
+Use `Works`, `Fails`, or `Limited: <short reason>` for tested cells. Add the exact browser version and ISO date (`YYYY-MM-DD`) to **Last verified**.
+
+## Network caveat
+
+A failed connection on one network does not by itself mean that the browser is incompatible. PeerCall has no bundled TURN relay, so restrictive NAT or firewall conditions can prevent an otherwise compatible browser pair from connecting. Retest on a normal network before recording a browser-level failure; see [optional TURN relay setup](turn-relay.md) for details.
+
+## Known limitations
+
+Add only reproduced, version-specific limitations here. Include enough detail for another contributor to repeat the check.


### PR DESCRIPTION
Closes #1.

Adds a conservative browser compatibility matrix and a repeatable verification procedure for desktop Chrome/Firefox/Safari, Android Chrome, iOS Safari, and installed PWA mode where available.

The initial cells are explicitly marked `Not verified` rather than making unsupported compatibility claims. The checklist records microphone permission, manual offer/answer exchange, audio connectivity, backgrounding, PWA behavior, browser/OS versions, and verification date. It also distinguishes browser failures from network/TURN limitations.

README now links to the matrix from Current Limitations.