### PR TITLE
chore: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What changed
- add weekly Dependabot checks for GitHub Actions
- limit concurrent update PRs to 5

## Why
The repository relies on GitHub Actions for static checks, but updates to action versions are currently manual. This keeps CI dependencies visible without adding runtime dependencies or changing application behavior.