### PR TITLE
Test required PWA shell assets in service worker precache

### DIFF
--- a/tests/static-smoke.mjs
+++ b/tests/static-smoke.mjs
@@ -149,6 +149,11 @@ const precacheAssets = [...assetListMatch[1].matchAll(/["'](.+?)["']/gu)].map((m
 assert(precacheAssets.length > 0, "Expected at least one precached asset");
 assert(new Set(precacheAssets).size === precacheAssets.length, "Expected unique precache asset paths");
 
+const requiredPrecacheAssets = ["./", "./index.html", "./manifest.json"];
+for (const asset of requiredPrecacheAssets) {
+  assert(precacheAssets.includes(asset), `Expected core PWA asset to be precached: ${asset}`);
+}
+
 for (const asset of precacheAssets) {
   assert(asset.startsWith("./"), `Expected relative precache asset path: ${asset}`);
   const localPath = asset === "./" ? "." : asset.slice(2);


### PR DESCRIPTION
## Summary
- require the app shell root, `index.html`, and `manifest.json` to remain in the service worker precache
- keep the existing path/existence checks for every cached asset

## Why
The smoke test verified that listed precache paths exist, but it did not fail if a core PWA shell asset was accidentally removed from `APP_ASSETS`. This makes offline-install regressions easier to catch in CI.

## Verification
- `npm test` is covered by the existing GitHub Actions workflow