### PR TITLE
test: verify manifest icon dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Private peer-to-peer browser audio calls with WebRTC.",
   "scripts": {
-    "test": "node tests/static-smoke.mjs"
+    "test": "node tests/static-smoke.mjs && node tests/pwa-icons.mjs"
   },
   "keywords": [
     "webrtc",

--- a/tests/pwa-icons.mjs
+++ b/tests/pwa-icons.mjs
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function pngDimensions(buffer, source) {
+  assert(buffer.length >= 24, `PNG is too short to contain an IHDR chunk: ${source}`);
+  assert(buffer.subarray(0, 8).equals(PNG_SIGNATURE), `Expected PNG signature: ${source}`);
+  assert(buffer.subarray(12, 16).toString("ascii") === "IHDR", `Expected PNG IHDR chunk: ${source}`);
+
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  assert(width > 0 && height > 0, `Expected positive PNG dimensions: ${source}`);
+  return `${width}x${height}`;
+}
+
+const manifest = JSON.parse(await readFile("manifest.json", "utf8"));
+assert(Array.isArray(manifest.icons) && manifest.icons.length > 0, "Expected manifest icons");
+
+for (const icon of manifest.icons) {
+  assert(typeof icon.src === "string" && icon.src.length > 0, "Expected icon source");
+  assert(/^\d+x\d+$/u.test(icon.sizes), `Expected explicit icon dimensions: ${icon.src}`);
+
+  const actualSize = pngDimensions(await readFile(icon.src), icon.src);
+  assert(
+    actualSize === icon.sizes,
+    `Manifest size mismatch for ${icon.src}: declared ${icon.sizes}, actual ${actualSize}`
+  );
+}
+
+console.log("PeerCall PWA icon dimension checks passed.");


### PR DESCRIPTION
## Summary

- add a focused PWA icon integrity check that reads PNG IHDR dimensions
- compare each file's actual dimensions with the size declared in `manifest.json`
- run the new check as part of `npm test`

## Why

The existing smoke test verifies that manifest icon files exist and that their declared `sizes` values look valid, but a wrong PNG could still be present under the expected filename. This catches that mismatch without changing application behavior.

## Verification

GitHub Actions must pass before merge.